### PR TITLE
Fix github links in /data and change them to be more consistent

### DIFF
--- a/data/AHGequip
+++ b/data/AHGequip
@@ -1,1 +1,1 @@
-https://github.com/TroopTrack/AHGequip/
+https://github.com/TroopTrack/AHGequip

--- a/data/Akiee
+++ b/data/Akiee
@@ -1,1 +1,1 @@
-https://github.com/rockiger/akiee-release/
+https://github.com/rockiger/akiee-release

--- a/data/BaijiMangaViewer
+++ b/data/BaijiMangaViewer
@@ -1,1 +1,1 @@
-https://github.com/shizkun/manga-viewer/releases
+https://github.com/shizkun/manga-viewer

--- a/data/Brackets
+++ b/data/Brackets
@@ -1,2 +1,2 @@
-https://github.com/zaggino/brackets-electron/releases
+https://github.com/zaggino/brackets-electron
 # Unofficial

--- a/data/Calculist
+++ b/data/Calculist
@@ -1,1 +1,1 @@
-https://github.com/calculist/calculist-desktop/
+https://github.com/calculist/calculist-desktop

--- a/data/Cerebral-Debugger
+++ b/data/Cerebral-Debugger
@@ -1,1 +1,1 @@
-https://github.com/cerebral/cerebral-debugger/
+https://github.com/cerebral/cerebral-debugger

--- a/data/Chigraph
+++ b/data/Chigraph
@@ -1,1 +1,1 @@
-https://github.com/chigraph/chigraph/releases
+https://github.com/chigraph/chigraph

--- a/data/DeDop-studio
+++ b/data/DeDop-studio
@@ -1,1 +1,1 @@
-https://github.com/DeDop/dedop-studio/
+https://github.com/DeDop/dedop-studio

--- a/data/FastQt
+++ b/data/FastQt
@@ -1,1 +1,1 @@
-https://github.com/labsquare/fastQt/releases
+https://github.com/labsquare/fastQt

--- a/data/Insomnia
+++ b/data/Insomnia
@@ -1,1 +1,1 @@
-https://github.com/getinsomnia/insomnia/releases
+https://github.com/getinsomnia/insomnia

--- a/data/MultiDir
+++ b/data/MultiDir
@@ -1,1 +1,1 @@
-https://github.com/OneMoreGres/multidir/
+https://github.com/OneMoreGres/multidir

--- a/data/Onshape
+++ b/data/Onshape
@@ -1,2 +1,2 @@
-https://github.com/develar/onshape-desktop-shell/
+https://github.com/develar/onshape-desktop-shell
 #

--- a/data/PhotoFlow
+++ b/data/PhotoFlow
@@ -1,1 +1,1 @@
-https://github.com/aferrero2707/PhotoFlow/
+https://github.com/aferrero2707/PhotoFlow

--- a/data/Standard_Notes
+++ b/data/Standard_Notes
@@ -1,2 +1,2 @@
-https://github.com/standardnotes/desktop/releases/download/v1.2.4/standard-notes-1.2.4-x86_64.AppImage
-# Link without version would be better
+https://github.com/standardnotes/desktop
+#

--- a/data/StopLight
+++ b/data/StopLight
@@ -1,1 +1,1 @@
-https://github.com/stoplightio/desktop/
+https://github.com/stoplightio/desktop

--- a/data/Tulip
+++ b/data/Tulip
@@ -1,1 +1,1 @@
-https://github.com/tulip5/tulip/
+https://github.com/tulip5/tulip

--- a/data/Tusk
+++ b/data/Tusk
@@ -1,1 +1,1 @@
-https://github.com/champloohq/tusk/
+https://github.com/champloohq/tusk

--- a/data/VLC
+++ b/data/VLC
@@ -1,2 +1,2 @@
-https://api.github.com/repos/darealshinji/vlc-AppImage/releases/tags/continuous
+https://github.com/darealshinji/vlc-AppImage
 #

--- a/data/Vespucci
+++ b/data/Vespucci
@@ -1,2 +1,2 @@
-https://github.com/VespucciProject/Vespucci/releases/download/1.0.0/Vespucci-1.0.0-linux-x86_64.AppImage
+https://github.com/VespucciProject/Vespucci
 # A link without version would be better

--- a/data/VidCutter
+++ b/data/VidCutter
@@ -1,2 +1,2 @@
-https://api.github.com/repos/ozmartian/vidcutter/releases/latest
+https://api.github.com/repos/ozmartian/vidcutter
 #

--- a/data/VidCutter
+++ b/data/VidCutter
@@ -1,2 +1,2 @@
-https://api.github.com/repos/ozmartian/vidcutter
+https://github.com/ozmartian/vidcutter
 #

--- a/data/Wire
+++ b/data/Wire
@@ -1,2 +1,2 @@
-https://github.com/wireapp/wire-desktop/releases/download/release%2F2.15.2751/wire-2.15.2751-x86_64.AppImage
-# Wire has an own release for Linux for each version. How do handle that?
+https://github.com/wireapp/wire-desktop
+#

--- a/data/appimagetool
+++ b/data/appimagetool
@@ -1,4 +1,4 @@
-https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+https://github.com/AppImage/AppImageKit
 # https://api.github.com/repos/AppImage/AppImageKit/releases/tags/continuous
 # Need to handle multiple AppImages per release for this? (to be decided)
 # We also need to think about how we handle multiple architectures... perhaps we should only care about x86_64 and 

--- a/data/caprine
+++ b/data/caprine
@@ -1,1 +1,1 @@
-https://github.com/sindresorhus/caprine/
+https://github.com/sindresorhus/caprine

--- a/data/devdocs-desktop
+++ b/data/devdocs-desktop
@@ -1,2 +1,2 @@
-https://github.com/egoist/devdocs-desktop/
+https://github.com/egoist/devdocs-desktop
 # Just the main URL to a GitHub Repo...

--- a/data/dexter_dev_env
+++ b/data/dexter_dev_env
@@ -1,1 +1,1 @@
-https://github.com/cfry/dde/releases
+https://github.com/cfry/dde

--- a/data/electron-webpack-dashboard
+++ b/data/electron-webpack-dashboard
@@ -1,1 +1,1 @@
-https://github.com/FormidableLabs/electron-webpack-dashboard/
+https://github.com/FormidableLabs/electron-webpack-dashboard

--- a/data/nteract
+++ b/data/nteract
@@ -1,1 +1,1 @@
-https://github.com/nteract
+https://github.com/nteract/nteract

--- a/data/sharexin
+++ b/data/sharexin
@@ -1,2 +1,0 @@
-https://github.com/ShareXin/ShareXin
-#

--- a/data/unified-communications
+++ b/data/unified-communications
@@ -1,1 +1,1 @@
-https://github.com/aricovindanevectone/hari/
+https://github.com/aricovindanevectone/hari

--- a/data/weweChat
+++ b/data/weweChat
@@ -1,1 +1,1 @@
-https://github.com/trazyn/weweChat/
+https://github.com/trazyn/weweChat


### PR DESCRIPTION
Fix broken links.
Remove duplicate link.
Fix github links to be consistent by doing the following:
Remove trailing slashes and /releases on github links.
Change github api links to be regular github links.
Change any direct links to AppImages hosted on github releases page to link to main github page.  It is very easy to find these images using Github's API.