### PR TITLE
Revert "Create Discord Stable"

### DIFF
--- a/data/discord-stable
+++ b/data/discord-stable
@@ -1,2 +1,0 @@
-https://github.com/simoniz0r/Discord-AppImage
-#


### PR DESCRIPTION
Reverts AppImage/appimage.github.io#196

AppImageHub is a directory of _upstream-provided_ AppImages. Please point to an official URL from the upstream software developer, https://discordapp.com.