### PR TITLE
Revert "Update packetsender.desktop"

### DIFF
--- a/database/PacketSender/packetsender.desktop
+++ b/database/PacketSender/packetsender.desktop
@@ -1,7 +1,6 @@
 [Desktop Entry]
 Type=Application
 Name=PacketSender
-Comment=Network utility for sending / receiving TCP, UDP, SSL
 Exec=PacketSender
 Icon=packetsender
 Categories=Network;


### PR DESCRIPTION
Thanks @KurtPfeifle but we won't merge this in this repository, because all data is automatically extracted from the upstream AppImages. The reason is that we do not want to maintain the metadata about applications ourselves due to lack of time and resources, and to avoid double work. Also it would be overwritten the next time our automated test runs.

So in other words, the only metadata about an application that we ever edit manually is the URL in the `data/<AppName>` file. Maybe we need to clarify this in the documentation.

Hence I ask you to send this patch to the original author of the application. One it is merged there, we can re-run our automated test in AppImageHub, and the information will be updated accordingly.

Thanks for your understanding.