### PR TITLE
Add Collabshot AppImage

### DIFF
--- a/data/Collabshot
+++ b/data/Collabshot
@@ -1,0 +1,1 @@
+https://api.collabshot.com/desktop/latest/linux


### PR DESCRIPTION
The AppImage can be downloaded from http://collabshot.com/
The direct permalink is https://api.collabshot.com/desktop/latest/linux