### PR TITLE
Create Celestia

### DIFF
--- a/data/Celestia
+++ b/data/Celestia
@@ -1,1 +1,1 @@
-https://github.com/furquan-lp/Celestia.AppImage/releases/download/1.5.1-i386/Celestia-1.5.1-i386.AppImage
+https://github.com/furquan-lp/Celestia.AppImage/releases/download/1.5.1-i386-1/Celestia-i386.AppImage

--- a/data/Celestia
+++ b/data/Celestia
@@ -1,0 +1,1 @@
+https://github.com/furquan-lp/Celestia.AppImage/raw/master/Celestia-1.5.1-i386.AppImage

--- a/data/Celestia
+++ b/data/Celestia
@@ -1,1 +1,1 @@
-https://github.com/furquan-lp/Celestia.AppImage/raw/master/Celestia-1.5.1-i386.AppImage
+https://github.com/furquan-lp/Celestia.AppImage/releases/download/1.5.1-i386/Celestia-1.5.1-i386.AppImage


### PR DESCRIPTION
Created Celestia from the autopackage found at the official site here: https://celestia.space/download.html.

Reasons for creating AppImage:
* autopackage is a dead format (autopackage.org redirects to some other irrelevant website)
* Celestia installer doesn't work as the autopackage link is broken (see [this issue](https://github.com/CelestiaProject/Celestia/issues/32) for more information)
* Celestia uses some very old libraries (libpng12 for example) so manually extracting the payload and running it won't work.

Steps taken:
* Download the autopackage [here](https://celestia.space/cc/celestia-linux-151) and run it inside a terminal.
* After the installation unsuccessfully exits, the payload is left behind in `/tmp` in the form of a zip archive.
* Extract the payload. It contains `bin` and `share` directories.
* Put the directories in a stable structure where it can be safely tested. `~/.local` the safest bet.
* Attempt to run the binary in `bin/` repeatedly and install and put the missing dependencies it requires in `~/.local/lib`.
* When the binary is finally able to run, create an AppImage directory structure and adapt the installer directories to it (putting `.desktop` at top-level and everything else in `usr/`).
* Put `AppRun` inside the AppImage directory and generate AppImage with `./appimagetool-x86_64.AppImage -n [APPIMAGE DIR]`.
* If `appimagetool` outputs errors related to the `.desktop` file, remove the erroneous lines and run again.

Known issues:
* Icon doesn't adapt to the user-selected icon theme. I don't know enough AppImages to do this (just learned to create them a few hours ago) and either way the above command needs an icon file (for some reason).

Misc.:
* libpng12 fetched from here: http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb
* Rest of the shared-libraries fetched from Debian's unstable repositories