### PR TITLE
Fix for obviously wrong URL

### DIFF
--- a/code/worker.sh
+++ b/code/worker.sh
@@ -290,7 +290,9 @@ echo "==========================================="
 # set -x
 
 # Until https://github.com/ximion/appstream/issues/128 is solved
-sudo wget -c -q "https://github.com/AppImage/AppImageHub/releases/download/deps/appstreamcli-x86_64.AppImage"
+# This URL was wrong:
+#sudo wget -c -q "https://github.com/AppImage/AppImageHub/releases/download/deps/appstreamcli-x86_64.AppImage"
+sudo wget -c -q "https://github.com/AppImage/appimage.github.io/releases/download/deps/appstreamcli-x86_64.AppImage"
 sudo chmod a+x appstreamcli-x86_64.AppImage
 # ./appstreamcli-x86_64.AppImage --appimage-extract ; mv squashfs-root appstreamcli.AppDir # TODO: remove need for this
 # Does not seem to work # alias appstreamcli='appstreamcli.AppDir/root_overlay/lib/x86_64-linux-gnu/ld-2.23.so --library-path appstreamcli.AppDir/root_overlay/usr/lib/x86_64-linux-gnu/ appstreamcli.AppDir/root_overlay/usr/bin/appstreamcli'


### PR DESCRIPTION
Location specified for appstreamcli.AppImage referred to "AppImageHub" instead of "appimage.github.io".