### PR TITLE
Create syncthingtray

### DIFF
--- a/data/syncthingtray
+++ b/data/syncthingtray
@@ -1,0 +1,1 @@
+https://download.opensuse.org/repositories/home:/mkittler:/appimage/AppImage/syncthingtray-latest-x86_64.AppImage


### PR DESCRIPTION
https://download.opensuse.org/repositories/home:/mkittler:/appimage/AppImage/ is officially mentioned on https://github.com/Martchus/syncthingtray/blob/107c8c26037fc7274bb3878a907e5cde53ad74c0/README.md so it is considered upstream-provided