### PR TITLE
List gem plugins under plugins

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,14 +56,12 @@ sass:
   style: :compressed 
 
 # Use the following plug-ins
-gems:
-  - jekyll-sitemap # Create a sitemap using the official Jekyll sitemap gem
-  - jekyll-redirect-from
-  - jekyll-feed
 
-# https://help.github.com/articles/search-engine-optimization-for-github-pages/
 plugins:
-  - jekyll-seo-tag
+  - jekyll-feed
+  - jekyll-redirect-from
+  - jekyll-seo-tag # https://help.github.com/articles/search-engine-optimization-for-github-pages/
+  - jekyll-sitemap # Create a sitemap using the official Jekyll sitemap gem
 
 # Exclude these files from your production _site
 exclude:


### PR DESCRIPTION
`gems` was the former key, now it's `plugins`.

Should avoid deprecation warning message at build.