### PR TITLE
Be more specific about release architecture

### DIFF
--- a/code/worker.sh
+++ b/code/worker.sh
@@ -32,7 +32,7 @@ if [ x"${URL:0:22}" == x"https://api.github.com" ] || [ x"${GHURL:0:22}" == x"ht
     GHURL="$URL"
   fi
   echo "GitHub API URL detected"
-  URL=$(wget -q "$GHURL" -O - | grep browser_download_url | grep -i AppImage | grep -v 'AppImage\.' | grep -i 64 | head -n 1 | cut -d '"' -f 4) # TODO: Handle more than one AppImage per release
+  URL=$(wget -q "$GHURL" -O - | grep browser_download_url | grep -i AppImage | grep -v 'AppImage\.' | grep -ie 'amd.\?64\|x86.64\|x64\|linux.\?64' | head -n 1 | cut -d '"' -f 4) # TODO: Handle more than one AppImage per release
   if [ x"" == x"$URL" ] ; then
     URL=$(wget -q "$GHURL" -O - | grep browser_download_url | grep -i AppImage | grep -v 'AppImage\.' | head -n 1 | cut -d '"' -f 4) # No 64-bit one found, trying any; TODO: Handle more than one AppImage per release
   fi


### PR DESCRIPTION
# Why ?
I for instance use the electron-builder, which allows me to build for arm64, armv7, amd64 (x86_64), ia32 with no effort.
> https://github.com/thomasnordquist/MQTT-Explorer/releases

I realized that my app was added with a fixed version. (0.0.3)
```
https://github.com/thomasnordquist/MQTT-Explorer/releases/download/v0.0.3/MQTT-Explorer-0.0.3-x86_64.AppImage
```
> https://github.com/AppImage/appimage.github.io/blob/master/data/MQTT-Explorer#L1
I figured the repository probably needs to know the architecture to render the Screenshot.

# Goal?
The release versions SHOULD NOT be required to be maintained by hand.

## Filter URLs by more detailed architecture strings
https://github.com/AppImage/appimage.github.io/blob/master/code/worker.sh#L35
Currently they are filtered with `grep -i 64` (case insensitive number?!?!).
This fails because I have a arm64 build.
Instead filter by
```
grep -ie 'amd.\?64\|x86.64\|x64\|linux.\?64' 
```

Testset:
```
Positive matches:
amd-64
AMD64
x86-64
X86_64
x64
linux64

Negative matches:
ARM64
i686
IA64
ARM-64
```

Filtered result:
```
amd-64
AMD64
x86-64
X86_64
x64
linux64
```

*Note*: `linux64` was not intended to match but did already with `x64` so I added `linux64` to the expression to make this more explicit

### I tested the expression in the current `data` directory:

#### How many repos can now avoid using fixed version (direct URL)
```
grep -rie 'amd.\?64\|x86.64\|x64\|linux.\?64' ./data | grep github | wc -l
> 86
```

#### Which repos still can't be matched
Actually just one, but it already is a direct URL
```
grep -rie '64' data | grep -vie 'amd.\?64\|x86.64\|x64\|linux.\?64'  | grep github                                                              
> data/sACNView:# Has no "64" in the filenname... https://github.com/docsteer/sacnview/pull/85
> data/twetter:https://github.com/NiewidzialnyCzlowiek/pubsub-webapp/releases/download/2.0.0/twetter.2.0.0.64bit.AppImage
```

# Which AppImages wont't work after the merge
I modified `worker.sh` so it will output all found AppImage URLs  
[current.txt](https://github.com/AppImage/appimage.github.io/files/2759269/current.txt)
[afterMerge.txt](https://github.com/AppImage/appimage.github.io/files/2759272/afterMerge.txt)

`diff current.txt afterMerge.txt`
```diff
154c154
< URL from GitHub API: https://github.com/hugetiny/negibox/releases/download/v0.1.5/negibox-0.1.5-arm64.AppImage
---
> URL from GitHub API: https://github.com/hugetiny/negibox/releases/download/v0.1.2/negibox-0.1.2-x86_64.AppImage
```

# Conclusion
No regression. 1 Screenshot more, 86 possible candidates for updates

[possibleUpdates.txt](https://github.com/AppImage/appimage.github.io/files/2759319/possibleUpdates.txt)
