### PR TITLE
Create GSequencer-x86_64.AppImage

### DIFF
--- a/data/GSequencer-x86_64.AppImage
+++ b/data/GSequencer-x86_64.AppImage
@@ -1,0 +1,1 @@
+https://github.com/gsequencer/gsequencer/releases/tag/v2.1.57


### PR DESCRIPTION
The AppImage was build using linuxfromscratch.org 7.9 as foundation. The full build of it is available from:

http://krähemann.com/products/minos-one_org.php

I have bundled Gtk+-2.0 libraries with its dependencies and fontconfig. But no Xorg or glibc dependencies.