### PR TITLE
Replace kaidan url with generic url

### DIFF
--- a/data/Kaidan
+++ b/data/Kaidan
@@ -1,1 +1,1 @@
-https://git.kaidan.im/kaidan/kaidan/-/jobs/3788/artifacts/raw/Kaidan-continuous-x86_64.AppImage
+https://invent.kde.org/kde/kaidan/-/jobs/artifacts/master/raw/Kaidan-continuous-x86_64.AppImage?job=linux-appimage


### PR DESCRIPTION
This url will always point to the latest build