### PR TITLE
Kaidan: Update screenshot url

### DIFF
--- a/apps/Kaidan.md
+++ b/apps/Kaidan.md
@@ -8,7 +8,7 @@ license: GPL-3.0+
 icons:
   - Kaidan/icons/scalable/kaidan.svg
 screenshots:
-- https://git.kaidan.im/kaidan/kaidan/uploads/da4886ea50581517bde0278a804b311c/kaidan-screenshot-0.3.png
+  - https://www.kaidan.im/images/screenshot.png
 
 authors:
 


### PR DESCRIPTION
this is already fixed in the appstream metadata, but I don't know a better way to update the information here.