### PR TITLE
Create admin-tools

### DIFF
--- a/data/admin-tools
+++ b/data/admin-tools
@@ -1,0 +1,1 @@
+https://download.opensuse.org/repositories/home:/dmulder:/YaST:/AppImage/AppImage/admin-tools-latest-x86_64.AppImage


### PR DESCRIPTION
This AppImage contains tools for administering an Active Directory domain controller (or alternatively, a Samba AD-DC). The module opens a simple chooser UI to pick between Active Directory Users and Computers, ADSI Edit, DNS Manager, and Group Policy Management Console.