### PR TITLE
Updating ttth to 1.6.0

### DIFF
--- a/data/ttth_1_6_0
+++ b/data/ttth_1_6_0
@@ -1,0 +1,1 @@
+https://github.com/yafp/ttth


### PR DESCRIPTION
Version 1.0.0 is currently listed in your repo - please consider updating it to the current version 1.6.0