### PR TITLE
Add Waterfox Classic

### DIFF
--- a/data/Waterfox
+++ b/data/Waterfox
@@ -1,1 +1,0 @@
-https://download.opensuse.org/repositories/home:/hawkeye116477:/waterfox/AppImage/Waterfox-latest-x86_64.AppImage

--- a/data/Waterfox_Alpha
+++ b/data/Waterfox_Alpha
@@ -1,1 +1,0 @@
-https://download.opensuse.org/repositories/home:/hawkeye116477:/waterfox/AppImage/waterfox-alpha-latest-x86_64.AppImage

--- a/data/Waterfox_Classic
+++ b/data/Waterfox_Classic
@@ -1,0 +1,1 @@
+https://download.opensuse.org/repositories/home:/hawkeye116477:/waterfox/AppImage/waterfox-classic-latest-x86_64.AppImage


### PR DESCRIPTION
There are now two Waterfox browsers => Classic and Current.

> Waterfox Classic YYYY.MM.X
> This branch is the legacy branch. There are no plans to retire this branch, and is going to be actively maintainted, the same as current.

> 
> 
> Waterfox Current YYYY.MM.X
> This branch is the modern, feature updated branch.


I'll add Current later.