### PR TITLE
Add AntiMicroX

### DIFF
--- a/data/AntiMicroX
+++ b/data/AntiMicroX
@@ -1,0 +1,2 @@
+https://github.com/pktiuk/antimicroX/releases/download/Appimage_submission/antimicroX-x86_64.AppImage
+#final link: https://github.com/juliagoda/antimicrox/releases/latest/download/antimicroX-x86_64.AppImage


### PR DESCRIPTION
Simple app used for mapping gamepads to Keyboard

It's repository is here: https://github.com/juliagoda/antimicrox

Currently added url points to testing repository.
It is part of issue: https://github.com/juliagoda/antimicroX/issues/128