### PR TITLE
Allow providing a webpage: attribute

### DIFF
--- a/code/worker.sh
+++ b/code/worker.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
 URL=$(cat $1 | head -n 1)
+if [[ $(cat $1 | head -n 2 | tail -n 1) == weblink:* ]]; then
+  WEBPAGE=$(cat text | head -n 2 | tail -n 1 | grep -P -o ':\K(.*)' | sed -e 's/^[[:space:]]*//')
+  echo "webpage: $WEBPAGE"
+else
+  WEBPAGE=""
+fi
+
 echo $URL
 
 if [ x"$TRAVIS_PULL_REQUEST" == xfalse ] ; then
@@ -490,6 +497,10 @@ sudo chmod a+x appstreamcli-x86_64.AppImage
   if [  x"$OBS_LINK" != x"" ] ; then
     echo "  - type: Download" >> apps/$INPUTBASENAME.md
     echo "    url: $OBS_LINK.mirrorlist" >> apps/$INPUTBASENAME.md
+  fi
+  if [  x"$WEBPAGE" != x"" ] ; then
+    echo "  - type: Web" >> apps/$INPUTBASENAME.md
+    echo "    url: $WEBPAGE" >> apps/$INPUTBASENAME.md
   fi
   # Add content of desktop file
   if [ -f "database/$INPUTBASENAME/$(dir -C -w 1 database/$INPUTBASENAME | grep -m1 '.desktop')" ]; then


### PR DESCRIPTION
Providing a link to the official webpage from where AppImages can be downloaded would be great additional information to the end-user. This would also enable web crawlers to automatically parse the AppImage link from the website instead of an absolute path. This would be helpful for AppImages that do not have their codebase on GitHub like Krita and Inkscape.

For example a new PR to add the inkscape AppImage would be:
```
https://gitlab.com/inkscape/inkscape/-/jobs/702815485/artifacts/download
weblink: https://inkscape.org/en/release/
```