### PR TITLE
Create AWS CLI v2

### DIFF
--- a/data/aws
+++ b/data/aws
@@ -1,0 +1,1 @@
+https://github.com/simnalamburt/awscliv2.appimage


### PR DESCRIPTION
Currently, AWS CLI v2 is being distributed in rather weird way. So I packaged it with AppImage, and publishing it to the AppImageHub will be greatly helpful to the AWS users. :)

##### References
- https://github.com/aws/aws-cli/issues/4947
- https://github.com/simnalamburt/awscliv2.appimage