### PR TITLE
Update Armagetron_Advanced to GitHub URL

### DIFF
--- a/data/Armagetron_Advanced
+++ b/data/Armagetron_Advanced
@@ -1,1 +1,1 @@
-http://download.armagetronad.org/appimage/ArmagetronAdvanced.AppImage
+https://github.com/ArmagetronAd/armagetronad


### PR DESCRIPTION
Seems like this gives a better user experience, especially adding a download link.
We do have several AppImages per release (server/client 32/64 bit), but the main one (64 bit client) is the shortest and therefore first in the list, and it seems to be picked by the processing script.