### PR TITLE
Add Waterfox Third Generation

### DIFF
--- a/data/Waterfox_Third_Generation
+++ b/data/Waterfox_Third_Generation
@@ -1,0 +1,1 @@
+https://download.opensuse.org/repositories/home:/hawkeye116477:/waterfox/AppImage/waterfox-g3-latest-x86_64.AppImage


### PR DESCRIPTION
Waterfox Third Generation is based on Gecko 78. Upstream replaced Waterfox Current with this, however it haven't some features known from older version for now and some users still prefer „Current", so for now I didn't removed Waterfox Current.