### PR TITLE
Fix VSCodium

### DIFF
--- a/apps/VSCodium.md
+++ b/apps/VSCodium.md
@@ -3,9 +3,7 @@ layout: app
 
 permalink: /VSCodium/
 description: Code Editing. Redefined.
-Code Editing. Redefined.
 license: MIT
-MIT
 
 icons:
   - VSCodium/icons/128x128/vscodium.png


### PR DESCRIPTION
It seems that this commit broke VSCodium's yaml: https://github.com/AppImage/appimage.github.io/commit/340c10de3e0a8c373ad86c90817ad74a834bc36c

I don't know if this is also the reason it disappeared from the hub.

Probably fixes: https://github.com/AppImage/appimage.github.io/issues/2341