### PR TITLE
Update yuzu to its correct GitHub page

### DIFF
--- a/data/yuzu
+++ b/data/yuzu
@@ -1,1 +1,1 @@
-https://github.com/pineappleEA/pineappleEA.github.io/releases/download/continuous/yuzu-x86_64.AppImage
+https://github.com/yuzu-emu/yuzu


### PR DESCRIPTION
Yuzu is currently broken, and points to an outdated non-official GitHub page that ships early access builds normally meant for Patreon supporters of Yuzu. The person owning the repo has not contributed a single line to the Yuzu project.