### PR TITLE
Plex Media Player

### DIFF
--- a/data/Plex_Media_Player
+++ b/data/Plex_Media_Player
@@ -1,0 +1,1 @@
+https://github.com/knapsu/plex-media-player-appimage


### PR DESCRIPTION
AppImage packages for Plex Media Player are now mirrored on GitHub. Adding Plex to AppImage Catalog would make it easier for users to get it.

Note: Plex Media Player requires network connection to work.