### PR TITLE
Update poplog

### DIFF
--- a/data/Poplog
+++ b/data/Poplog
@@ -1,1 +1,1 @@
-https://github.com/GetPoplog/Seed/releases/latest/download/Poplog-x86_64.AppImage
+https://github.com/GetPoplog/Seed


### PR DESCRIPTION
Our poplog entry has not appeared on https://appimage.github.io/apps/
(follow up from https://github.com/AppImage/appimage.github.io/pull/2602)
This commit changes the link from one that directly points towards an AppImage file to our repo in the hope this rectifies the issue.