### PR TITLE
Update Cryptomator

### DIFF
--- a/data/Cryptomator
+++ b/data/Cryptomator
@@ -1,2 +1,1 @@
-https://dl.bintray.com/cryptomator/cryptomator/cryptomator-1.4.1-x86_64.AppImage
-# Link without version would be better
+https://github.com/cryptomator/cryptomator


### PR DESCRIPTION
Instead of a specific version, we're no using

> [...] a link to the GitHub repository that hosts AppImages on its Releases page.

As suggested [in the docs](https://docs.appimage.org/packaging-guide/distribution.html#appimagehub).