### PR TITLE
Update Cryptomator to 1.6.5

### DIFF
--- a/data/Cryptomator
+++ b/data/Cryptomator
@@ -1,2 +1,2 @@
-https://github.com/cryptomator/cryptomator/releases/download/1.6.5/cryptomator-1.6.5-x86_64.AppImage.asc
+https://github.com/cryptomator/cryptomator/releases/download/1.6.5/cryptomator-1.6.5-x86_64.AppImage
 # Link without version would be better (currently blocked, see #2827)

--- a/data/Cryptomator
+++ b/data/Cryptomator
@@ -1,2 +1,2 @@
-https://dl.bintray.com/cryptomator/cryptomator/cryptomator-1.4.1-x86_64.AppImage
-# Link without version would be better
+https://github.com/cryptomator/cryptomator/releases/download/1.6.5/cryptomator-1.6.5-x86_64.AppImage.asc
+# Link without version would be better (currently blocked, see #2827)


### PR DESCRIPTION
Alternative to #2827, as linking to GitHub repo seems broken, so I'll stick with a specific version.