### PR TITLE
Stop Using gitcdn.xyz (Fixes #2811)

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,7 +15,7 @@ layout: default
   <header>
  
     <h1 style="text-align:center" id="{{ post.title | replace: "_", " " }}">
-      {% if post.icons[0] %}<img height="128" width="128" src="https://gitcdn.xyz/repo/AppImage/appimage.github.io/master/database/{{post.icons[0]}}"/><br/>{% else %}{% endif %}
+      {% if post.icons[0] %}<img height="128" width="128" src="https://appimage.github.io/database/{{post.icons[0]}}"/><br/>{% else %}{% endif %}
       {% if page.title %}{{ page.title | replace: "_", " " }}{% else %}{{ page.name | remove: ".md" | replace: "_", " " }}{% endif %}</h1>
     {% if post.generic %}<p>{{ post.generic }}</p>{% endif %}
 

--- a/pages/apps.md
+++ b/pages/apps.md
@@ -22,7 +22,7 @@ We currently have {{ site.pages | size }} [apps]({{ site.baseurl }}/apps/) in ou
         <tr id="{{ post.url }}">
           <td style="vertical-align: top;">
             <a href="{{ site.baseurl }}{{ post.url }}" style="font-weight:bold">
-            {% if post.icons[0] %}<img height="64" width="64" src="https://gitcdn.xyz/repo/AppImage/appimage.github.io/master/database/{{post.icons[0]}}"/>{% else %}<img style="opacity: 0.5;" height="64" width="64" src="https://img.icons8.com/ios/1600/ios-application-placeholder.png"/>{% endif %}<br>
+            {% if post.icons[0] %}<img height="64" width="64" src="https://appimage.github.io/database/{{post.icons[0]}}"/>{% else %}<img style="opacity: 0.5;" height="64" width="64" src="https://img.icons8.com/ios/1600/ios-application-placeholder.png"/>{% endif %}<br>
               {% if post.title %}{{ post.title }}{% else %}{{ post.name | remove: ".md" }}{% endif %}
             </a>
             {% if post.installation %}<span class="octicon octicon-package" title="Package available"></span>{% endif %}


### PR DESCRIPTION
It's *really* slow (in my experience), has been down a few times, and is fairly redundant when everything's running off of GitHub anyways.