### PR TITLE
Create PackSquash

### DIFF
--- a/data/PackSquash
+++ b/data/PackSquash
@@ -1,0 +1,1 @@
+https://github.com/ComunidadAylas/PackSquash/releases/download/v0.3.1/PackSquash-v0.3.1-x86_64.AppImage


### PR DESCRIPTION
PackSquash is a CLI application for optimizing Minecraft resource packs I've authored. I've made a new release recently and started distributing AppImages for it, and I think it'd be great for users if they were on AppImageHub too. I think the AppImage meets the requirements mentioned in the readme.

I also build AppImages for the ARM64 architecture, but I've added a link to the x64 AppImage in the PR, following the style of other PRs. Please let me know if this is a problem.