### PR TITLE
Update Endless Sky

### DIFF
--- a/data/Endless_Sky
+++ b/data/Endless_Sky
@@ -1,4 +1,4 @@
-https://github.com/endless-sky/endless-sky/releases/download/v0.9.12/endless-sky-amd64-v0.9.12.AppImage
+https://github.com/endless-sky/endless-sky/releases/download/v0.9.14/endless-sky-amd64-v0.9.14.AppImage
 # https://github.com/MCOfficer/endless-sky/suites/529714558/artifacts/3067456
 # https://github.com/endless-sky/endless-sky/issues/4923#issuecomment-599425380
 # https://github.com/endless-sky/endless-sky/releases/download/v0.9.11/endless-sky-x86_64.AppImage


### PR DESCRIPTION
Update to the latest stable release 0.9.14. https://github.com/endless-sky/endless-sky/releases/tag/v0.9.14