### PR TITLE
yuzu: Point to latest release on GitHub

### DIFF
--- a/data/yuzu
+++ b/data/yuzu
@@ -1,2 +1,2 @@
-https://github.com/yuzu-emu/yuzu-mainline/releases/download/mainline-0-943/yuzu-20220306-3a401ca22.AppImage
+https://github.com/yuzu-emu/yuzu-mainline/releases/latest
 # The architecture is missing in the filename


### PR DESCRIPTION
Apparently other community members have added the [yuzu](https://github.com/yuzu-emu/yuzu) AppImage to AppImageHub, unbeknownst to us. This makes the link follow the latest Mainline GitHub release, since we ideally release new builds daily.