### PR TITLE
Create SheepShaverBasiliskII

### DIFF
--- a/data/SheepShaverBasiliskII
+++ b/data/SheepShaverBasiliskII
@@ -1,0 +1,1 @@
+https://github.com/Korkman/macemu-appimage-builder


### PR DESCRIPTION
Two programs, SheepShaver and Basilisk II, in two architectures: i386 and x86_64