### PR TITLE
Create RedDiamond

### DIFF
--- a/data/RedDiamond
+++ b/data/RedDiamond
@@ -1,1 +1,1 @@
-https://sourceforge.net/projects/reddiamond/files/AppImages/
+https://downloads.sourceforge.net/project/reddiamond/AppImages/reddiamond-3.2.0-x86_64.AppImage

--- a/data/RedDiamond
+++ b/data/RedDiamond
@@ -1,0 +1,1 @@
+https://sourceforge.net/projects/reddiamond/files/AppImages/

--- a/data/RedDiamond
+++ b/data/RedDiamond
@@ -1,2 +1,1 @@
 https://downloads.sourceforge.net/project/reddiamond/AppImages/reddiamond-3.2.0-x86_64.AppImage
-#

--- a/data/RedDiamond
+++ b/data/RedDiamond
@@ -1,1 +1,2 @@
 https://downloads.sourceforge.net/project/reddiamond/AppImages/reddiamond-3.2.0-x86_64.AppImage
+#


### PR DESCRIPTION
RedDiamond text editor. Unlike most PC based editors this one focuses on providing EDT keypad navigation. This AppImage is created using https://github.com/simoniz0r/deb2appimage and the .deb created for Ubuntu 18.04 because Ubuntu 16.04 is officially EOL. I tested it on Manjaro Cinnamon and it worked fine there.