### PR TITLE
Update APhotoToolLibre

### DIFF
--- a/data/APhotoToolLibre
+++ b/data/APhotoToolLibre
@@ -1,1 +1,1 @@
-https://github.com/aphototool/A-Photo-Tool-Libre/releases/download/v1.0.3-2/aphototoollibre_1.0.3-2_x86_64.AppImage
+https://github.com/aphototool/A-Photo-Tool-Libre/


### PR DESCRIPTION
New version of the app, new screen capture.

This is an attempt to make https://appimage.github.io/APhotoToolLibre/ reflect current application state. At this time https://appimage.github.io/APhotoToolLibre/ does look to be based on old version of the app. If there is an other way I'm happy to try that.
