### PR TITLE
Add OpenRA

### DIFF
--- a/data/OpenRA
+++ b/data/OpenRA
@@ -1,1 +1,1 @@
-http://github.com/OpenRA/OpenRA
+https://github.com/OpenRA/OpenRA/releases/download/release-20210321/OpenRA-Red-Alert-x86_64.AppImage

--- a/data/OpenRA
+++ b/data/OpenRA
@@ -1,0 +1,1 @@
+http://github.com/OpenRA/OpenRA


### PR DESCRIPTION
Resubmission of https://github.com/AppImage/appimage.github.io/pull/1612 as AppImages now come with bundled .NET instead of Mono and the CI system here was changed from Travis CI to GitHub Actions which seems to be able to take a screenshot from SDL 2. Compare https://github.com/AppImage/appimage.github.io/pull/3070.