### PR TITLE
Create Rice_Manager

### DIFF
--- a/data/Rice_Manager
+++ b/data/Rice_Manager
@@ -1,0 +1,1 @@
+https://github.com/Narmis-E/rice-manager


### PR DESCRIPTION
changed AppRun path to use usr/bin/python3.8. This should fix the namespace error as it wasn't finding PyGObject. First time doing this sort of stuff, sorry about my pitiful efforts.