### PR TITLE
Create file "lux" in appimage.github.io/data

### DIFF
--- a/data/lux
+++ b/data/lux
@@ -1,0 +1,1 @@
+https://bitbucket.org/kfj/pv/downloads/lux-master-x86_64.AppImage


### PR DESCRIPTION
This file is to make the most recent lux AppImage build visible in the AppImage catalog. The URL points to a recent build from lux master - not quite a 'nightly', but close to it, and updated every now and then when there were relevant changes to the lux repo.