### PR TITLE
updated metadata.xml, new build of lux 1.1.8 on ubuntu 20.04

### DIFF
--- a/data/lux
+++ b/data/lux
@@ -1,3 +1,4 @@
 https://bitbucket.org/kfj/pv/downloads/lux-master-x86_64.AppImage
 # This URL provides an AppImage built from lux master and is updated
 # at irregular intervals. Versioned AppImages reside in the same folder.
+# The latest upload has lux 1.1.8 and updated metadata.xml


### PR DESCRIPTION
The latest upload of https://bitbucket.org/kfj/pv/downloads/lux-master-x86_64.AppImage has a new build of lux 1.1.8 made on ubuntu 20.04 and more metadata in metadat.xml to produce a better catalog page.