### PR TITLE
Trigger AppImageHub update for Mayo entry

### DIFF
--- a/data/Mayo
+++ b/data/Mayo
@@ -1,1 +1,2 @@
 https://github.com/fougue/mayo
+# Trigger update on AppImageHub


### PR DESCRIPTION
Mayo entry on AppImageHub needs to be updated as new AppStream metainfo is provided in latest Mayo release