### PR TITLE
Create SeriousSamClassic-VK

### DIFF
--- a/data/SeriousSamClassic-VK
+++ b/data/SeriousSamClassic-VK
@@ -1,0 +1,1 @@
+https://github.com/tx00100xt/SeriousSamClassic-VK/releases/download/1.10.6d/SeriousSamTFE-Vk-1.10.6d-x86_64.AppImage


### PR DESCRIPTION
Differs from SeriousSamClassic in the presence of a Vulkan render. If Vulkan is available, the user can select it from the menu. OpenGL render by default

**Tested on Live ISO:**
- ubuntu-16.04.7-desktop-amd64.iso
- ubuntu-18.04.6-desktop-amd64.iso
- ubuntu-20.04.6-desktop-amd64.iso
- debian-live-9.13.0-amd64-lxde.iso
- linuxmint-21.3-cinnamon-64bit.iso
- Fedora-Workstation-Live-x86_64-39-1.5.iso