### PR TITLE
Update RetroArch download path

### DIFF
--- a/data/RetroArch
+++ b/data/RetroArch
@@ -1,3 +1,3 @@
-https://github.com/hizzlekizzle/RetroArch-AppImage/releases/download/Linux_LTS_Nightlies/RetroArch-Linux-x86_64-Nightly.AppImage
+http://buildbot.libretro.com/nightly/linux/x86_64/
 # https://github.com/hizzlekizzle/RetroArch-AppImage/issues/1#issuecomment-667317376
 #RetroArch


### PR DESCRIPTION
we've been making official AppImage builds for a while and have since sunsetted the hizzlekizzle repo builds, but I forgot this old link was still floating around. This should get people pointed to the latest and greatest.