### PR TITLE
Add new Gridcoin wallet version 5.4.7.0-leisure

### DIFF
--- a/data/Gridcoin-Research
+++ b/data/Gridcoin-Research
@@ -1,0 +1,1 @@
+https://github.com/gridcoin-community/Gridcoin-Research/releases/download/5.4.7.0/GridcoinResearch-5.4.7.0-x86-64.appimage

--- a/data/GridcoinResearch-5.4.5.0
+++ b/data/GridcoinResearch-5.4.5.0
@@ -1,1 +1,0 @@
-https://github.com/Igor-Misic/Gridcoin-Research/releases/download/5.4.5.0/GridcoinResearch-5.4.5.0-x86_64.AppImage


### PR DESCRIPTION
Remove the old version 5.4.5.0 (it is not supported on the Gridcoin chain anymore)
Add new version 5.4.7.0-leisure

The previous version was also added by me: https://github.com/AppImage/appimage.github.io/pull/3190