### PR TITLE
Create Alpine_Client

### DIFF
--- a/data/Alpine_Client
+++ b/data/Alpine_Client
@@ -1,0 +1,1 @@
+https://metadata.alpineclient.com/install/linux/x86_64/appimage


### PR DESCRIPTION
https://metadata.alpineclient.com/install/linux/x86_64/appimage

(recreating again to rerun CI)

I fixed the problem with Zenity missing from the AppImage. The window should work now.