### PR TITLE
Correct AppImage list sorting

### DIFF
--- a/pages/apps.md
+++ b/pages/apps.md
@@ -16,7 +16,7 @@ We currently have {{ site.pages | size }} [apps]({{ site.baseurl }}/apps/) in ou
     </tr>
   </thead>
   <tbody>
-    {% assign sorted = site.pages | sort: 'title' %}
+    {% assign sorted = site.pages | sort_natural: 'title' %}
     {% for post in sorted %}
       {% if post.layout == 'app' && post.published != 'false' %}
         <tr id="{{ post.url }}">


### PR DESCRIPTION
This pull request corrects the default sorting of the table containing all AppImages.

Currently, the default sorting is case-sensitive which makes it not alphabetical. Only after you click on the title tab, the list is sorted correctly. This pull request fixes this.