### PR TITLE
Skip screenshot upload, if screenshot is present in `*.appdata.xml`

### DIFF
--- a/code/worker.sh
+++ b/code/worker.sh
@@ -570,9 +570,12 @@ echo "==========================================="
 if [ "$IS_PULLREQUEST" = true ]; then
   cat "apps/${INPUTBASENAME}.md" || exit 1
   cat "database/${INPUTBASENAME}/"*.desktop || exit 1 # Asterisk must not be inside quotes, https://travis-ci.org/AppImage/appimage.github.io/builds/360847207#L782
-  ls -lh "database/${INPUTBASENAME}/screenshot.png" || exit 1
-  wget -q https://raw.githubusercontent.com/tremby/imgur.sh/1c64feeefb6590741eb3d034575f9c788469b0a8/imgur.sh
-  bash imgur.sh "database/${INPUTBASENAME}/screenshot.png"
+  # If no screenshot is present in the AppStream metadata, upload the screenshot we took earlier
+  if [ x"$SCREENSHOT" == x"" ] ; then
+      ls -lh "database/${INPUTBASENAME}/screenshot.png" || exit 1
+      wget -q https://raw.githubusercontent.com/tremby/imgur.sh/1c64feeefb6590741eb3d034575f9c788469b0a8/imgur.sh
+      bash imgur.sh "database/${INPUTBASENAME}/screenshot.png"
+  fi
   echo ""
   echo "We will assume the test is OK (a pull request event was triggered and the required files exist)."
   exit 0


### PR DESCRIPTION
Trying to reduce load on Imgur to avoid rate limiting. The added condition at the end of the script relies on `$SCREENSHOT` being only set if a screenshot was found in `*.appdata.xml`:

https://github.com/AppImage/appimage.github.io/blob/a41e2b165b1ef8b8816d96de1484d3f1b92c397f/code/worker.sh#L475-L486

---

Side note: While this is a rather minimal change, I also thought about skipping screenshot creation altogether if a screenshot is already specified in the AppStream metadata. This would be on par with the intend expressed in this comment:

https://github.com/AppImage/appimage.github.io/blob/a41e2b165b1ef8b8816d96de1484d3f1b92c397f/code/worker.sh#L208-L209

However, this would be a larger diff, making it harder to review. Furthermore I'm not sure if creating a screenshot is also used as some kind of smoke test, if the application actually starts a GUI.

