### PR TITLE
Update Gai version 1.2.1

### DIFF
--- a/data/Gai
+++ b/data/Gai
@@ -1,1 +1,2 @@
 https://webpath.iche2.com/release/Gai-1.2.1-x86_64.AppImage
+#


### PR DESCRIPTION
version:1.2.0
date:2025-06-25
---
support Gemini 2.5 Flash dynamic thinking.
support Gemini 2.0 Flash preview image generation.
remove Gemini 1.5 models are now discontinued.