### PR TITLE
Add Speak-to-AI v1.1.0

### DIFF
--- a/data/Speak-to-AI
+++ b/data/Speak-to-AI
@@ -1,7 +1,1 @@
-name: Speak-to-AI
-version: 1.1.0
-description: Offline speech-to-text desktop app for voice input into any active window
-homepage: https://github.com/AshBuk/speak-to-ai
-license: MIT
-url: https://github.com/AshBuk/speak-to-ai/releases/download/v1.1.0/speak-to-ai-v1.1.0.AppImage
-icon: https://raw.githubusercontent.com/AshBuk/speak-to-ai/master/icons/io.github.ashbuk.speak-to-ai.png
+https://github.com/AshBuk/speak-to-ai

--- a/data/Speak-to-AI.yml
+++ b/data/Speak-to-AI.yml
@@ -1,7 +1,0 @@
-https://github.com/AshBuk/speak-to-ai/releases/download/v1.1.0/speak-to-ai-v1.1.0.AppImage
-name: Speak-to-AI
-version: 1.1.0
-description: Offline speech-to-text desktop app for voice input into any active window
-homepage: https://github.com/AshBuk/speak-to-ai
-license: MIT
-icon: https://raw.githubusercontent.com/AshBuk/speak-to-ai/master/icons/io.github.ashbuk.speak-to-ai.png


### PR DESCRIPTION
## Speak-to-AI v1.1.0

Minimalist, privacy-focused desktop app for offline speech-to-text. 
Converts voice input into any active window using Whisper locally. 

- AppImage package for Linux (X11/Wayland)
- Global hotkeys, clipboard & automatic typing
- System tray integration (KDE / GNOME — requires AppIndicator extension)
- Multi-language support
- Privacy-first: no data sent to servers

Homepage: https://github.com/AshBuk/speak-to-ai
License: MIT
