### PR TITLE
ci: trigger publisher by workflow file path 

### DIFF
--- a/.github/workflows/publish-pr-screenshot.yml
+++ b/.github/workflows/publish-pr-screenshot.yml
@@ -2,7 +2,8 @@ name: Publish PR Screenshot
 
 on:
   workflow_run:
-    workflows: ["Test"]
+    workflows:
+      - ".github/workflows/test.yml"
     types: [completed]
 
 jobs:


### PR DESCRIPTION
 - Listen by workflow file path .github/workflows/test.yml (more robust)

Runs only in upstream repo; requires Actions “Workflow permissions: Read and write”