### PR TITLE
Add XtoMarkdown

### DIFF
--- a/data/XtoMarkdown.md
+++ b/data/XtoMarkdown.md
@@ -1,0 +1,1 @@
+https://github.com/tx2z/xtomarkdown/releases/download/v1.0.2/XtoMarkdown-1.0.2-x86_64.AppImage


### PR DESCRIPTION
XtoMarkdown is a cross-platform GUI application for converting documents (DOCX, PDF, PPTX, etc.) to Markdown. Supports Pandoc and MarkItDown engines.