### PR TITLE
Add DinoX - Modern XMPP Messenger (v0.7.3)

### DIFF
--- a/data/DinoX.yml
+++ b/data/DinoX.yml
@@ -1,0 +1,16 @@
+name: DinoX
+categories:
+  - Network
+  - Chat
+authors:
+  - name: Ralf Peter
+links:
+  - type: GitHub
+    url: rallep71/dinox
+  - type: Download
+    url: https://github.com/rallep71/dinox/releases
+icons:
+  - https://raw.githubusercontent.com/rallep71/dinox/master/main/data/icons/hicolor/scalable/apps/im.github.rallep71.DinoX.svg
+screenshots:
+  - https://dinox.handwerker.jetzt/assets/mucji.png
+


### PR DESCRIPTION
Adding **DinoX** - a modern XMPP/Jabber messenger for Linux.

## About DinoX
- **Homepage**: https://dinox.handwerker.jetzt
- **Source**: https://github.com/rallep71/dinox
- **AppImage**: https://github.com/rallep71/dinox/releases

## Features
- MUJI Group Video Calls
- Voice Messages  
- OMEMO End-to-End Encryption
- System Tray Support
- 45 Languages (100% translated)
- 67+ XEPs supported
- GTK4/libadwaita interface

## Changes from previous PR (#3581)
The previous submission had issues with bundled system libraries causing crashes. 
This has been fixed in v0.7.3:
- Removed all blacklisted system libraries (libc, libstdc++, libX11, etc.)
- Removed bundled gst-plugin-scanner that caused GStreamer warnings
- AppImage now properly uses host system libraries
- Added zsync support for auto-updates

The AppImage should now pass all compatibility tests.

## Testing
Built and tested on Ubuntu 22.04 and 24.04.