### PR TITLE
Update xonsh AppImage URL to version 0.21.2

### DIFF
--- a/data/xonsh
+++ b/data/xonsh
@@ -1,1 +1,1 @@
-https://github.com/xonsh/xonsh/releases/download/0.20.0/xonsh-x86_64.AppImage
+https://github.com/xonsh/xonsh/releases/download/0.21.2/xonsh-x86_64.AppImage


### PR DESCRIPTION
The xonsh shell version 0.21.2 is a big checkpoint and the final version released in 2025 so I tend to pin it in every project.