### PR TITLE
Add link to port-slayer AppImage

### DIFF
--- a/data/port-slayer
+++ b/data/port-slayer
@@ -1,1 +1,1 @@
-https://github.com/mrayushmehrotra/port-slayer/blob/main/webpage/appimage/port-slayer-x86_64.AppImage
+https://github.com/mrayushmehrotra/port-slayer/releases/download/v0.1.0/port-slayer


### PR DESCRIPTION
This app is a GUI wrapper for killing the ports as an alternative of lsof