### PR TITLE
Add iPhotron project link to data directory

### DIFF
--- a/data/iPhotron
+++ b/data/iPhotron
@@ -1,0 +1,1 @@
+https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager


### PR DESCRIPTION
This pull request adds iPhotron to AppImageHub.

The corresponding file in data/ contains the GitHub repository URL for automated inspection.

Thank you.