### PR TITLE
Add Clippy Clipboard Manager

### DIFF
--- a/apps/Clippy_Clipboard_Manager.md
+++ b/apps/Clippy_Clipboard_Manager.md
@@ -1,0 +1,37 @@
+---
+layout: app
+
+permalink: /Clippy_Clipboard_Manager/
+description: Clipboard Manager built with Rust & Typescript
+license: MIT
+
+icons:
+  - Clippy_Clipboard_Manager/icons/256x256/clippy.png
+
+screenshots:
+  - Clippy_Clipboard_Manager/screenshot.png
+
+authors:
+  - name: 0-don
+    url: https://github.com/0-don
+
+links:
+  - type: GitHub
+    url: 0-don/clippy
+  - type: Download
+    url: https://github.com/0-don/clippy/releases
+
+desktop:
+  Desktop Entry:
+    Name: Clippy
+    Comment: Clipboard Manager built with Rust & Typescript
+    Exec: AppRun
+    Terminal: false
+    Type: Application
+    Icon: clippy
+    X-AppImage-Version: 1.5.8
+    Categories: Utility
+  AppImageHub:
+    X-AppImage-Type: 2
+    X-AppImage-Architecture: x86_64
+---


### PR DESCRIPTION
## Summary

Adding Clippy Clipboard Manager to the AppImage Hub catalog.

- **Name:** Clippy
- **Description:** Clipboard Manager built with Rust & Typescript
- **Category:** Utility
- **License:** MIT
- **Homepage:** https://github.com/0-don/clippy
- **AppImage:** https://github.com/0-don/clippy/releases/download/v1.5.8/clippy_1.5.8_amd64.AppImage

Note: The listing uses `Clippy_Clipboard_Manager` as the identifier since `clippy` is already taken by another project.