### PR TITLE
Add My Honda+ for desktop

### DIFF
--- a/data/My-Honda-for-desktop
+++ b/data/My-Honda-for-desktop
@@ -1,0 +1,1 @@
+https://github.com/enricobattocchi/myhondaplus-desktop


### PR DESCRIPTION
Unofficial desktop GUI for Honda Connect Europe (My Honda+).

- Repository: https://github.com/enricobattocchi/myhondaplus-desktop
- License: GPL-3.0-or-later
- AppImage filename: `My-Honda-for-desktop-<version>-x86_64.AppImage`