### PR TITLE
Create GmodContentInstaller

### DIFF
--- a/data/GmodContentInstaller
+++ b/data/GmodContentInstaller
@@ -1,0 +1,1 @@
+https://github.com/Serpensin/GmodContentInstaller


### PR DESCRIPTION
Add GmodContentInstaller.
This app allows users to easily install content for Gmod, like CSS-Content.