### PR TITLE
Add QSL-Card-Generator

### DIFF
--- a/data/QSL-Card-Generator
+++ b/data/QSL-Card-Generator
@@ -1,0 +1,1 @@
+https://github.com/igonzalezb/QSL-Card-Generator


### PR DESCRIPTION
# QSL-Card-Generator
A desktop application for amateur radio operators designed to generate QSL cards in bulk from ADIF log files

- Repository: https://github.com/igonzalezb/QSL-Card-Generator
- WebPage: https://igonzalezb.github.io/QSL-Card-Generator/
- AppImage filename: `QSL_Card_Generator-x86_64.AppImage`