### PR TITLE
Add bb-imager-gui

### DIFF
--- a/data/bb-imager-gui
+++ b/data/bb-imager-gui
@@ -1,0 +1,1 @@
+https://github.com/beagleboard/bb-imager-rs/releases/download/1.0.1/bb-imager-gui_1.0.1_x86_64.AppImage


### PR DESCRIPTION
- Since this repo publishes multiple binaries (bb-imager-gui and bb-imager-cli), the repo name is not the same as the AppImage name. As such, I have provided a full link to x86_64 binary similar to mpc-qt PR did [0].
- The release contains AppImage builds for x86_64 and arm64.
- SD Card and board firmware flashing utility: https://github.com/beagleboard/bb-imager-rs

[0]: https://github.com/AppImage/appimage.github.io/pull/3624