### PR TITLE
Add YallaVideo

### DIFF
--- a/data/YallaVideo
+++ b/data/YallaVideo
@@ -1,0 +1,1 @@
+https://github.com/monzer15/yalla-video-releases


### PR DESCRIPTION
Adding Yalla Video, an Electron-based desktop video downloader for YouTube and 1000+ sites. AppImage is published on every release at https://github.com/monzer15/yalla-video-releases/releases