### PR TITLE
Add Retromanager — Linux retro ROM manager

### DIFF
--- a/apps/Retromanager.md
+++ b/apps/Retromanager.md
@@ -1,0 +1,23 @@
+---
+layout: app
+
+permalink: /Retromanager/
+description: Linux retro ROM manager — browse, download and launch classic games from Archive.org
+license: MIT
+
+screenshots:
+  - https://raw.githubusercontent.com/Borussia80/retromanager/main/docs/screenshots/rom_list.png
+  - https://raw.githubusercontent.com/Borussia80/retromanager/main/docs/screenshots/grid_view.png
+  - https://raw.githubusercontent.com/Borussia80/retromanager/main/docs/screenshots/download.png
+  - https://raw.githubusercontent.com/Borussia80/retromanager/main/docs/screenshots/detail.png
+
+authors:
+  - name: Borussia80
+    url: https://github.com/Borussia80
+
+links:
+  - type: GitHub
+    url: Borussia80/retromanager
+  - type: Download
+    url: https://github.com/Borussia80/retromanager/releases
+---


### PR DESCRIPTION
## Retromanager

Linux retro ROM manager — browse, download and launch classic games from Archive.org.

- **GitHub:** https://github.com/Borussia80/retromanager
- **Latest release:** https://github.com/Borussia80/retromanager/releases/tag/v2.3.2
- **AppImage:** https://github.com/Borussia80/retromanager/releases/download/v2.3.2/retromanager-2.3.2-x86_64.AppImage
- **License:** MIT

### What it does

- Browse and download ROMs from Archive.org (NES, SNES, N64, GB/GBC/GBA, Sega, Atari, NEC, SNK, MAME, PlayStation, PS2, PSP)
- RetroArch health check per platform (detects missing cores and BIOS files)
- Full-text search (SQLite FTS5) across 40k+ ROMs
- Concurrent downloads with resume, exponential retry and SHA1/MD5/CRC32 verification
- Lutris integration, cover art thumbnails, favorites and history
- Dark PyQt6 UI, self-contained AppImage