### PR TITLE
Add SiliSim

### DIFF
--- a/data/SiliSim
+++ b/data/SiliSim
@@ -1,0 +1,1 @@
+https://silisim.com/downloads/silisim-linux-x86_64.AppImage


### PR DESCRIPTION
## Summary
- Adds [SiliSim](https://silisim.com/), a 2D silicon logic simulator for learning and building digital circuits.
- AppImage is hosted at a stable URL: https://silisim.com/downloads/silisim-linux-x86_64.AppImage

## AppImage details
- Includes AppStream metainfo (`com.silisim.SiliSim.appdata.xml`)
- Desktop entry passes `desktop-file-validate`
- Works offline (native desktop app, no network required)
- Passes `appdir-lint.sh` locally

## Test plan
- [ ] CI automated review passes (green check)
- [ ] Screenshot is captured from the running AppImage