### PR TITLE
Add Goink — desktop AI novel-writing agent

### DIFF
--- a/data/Goink
+++ b/data/Goink
@@ -1,0 +1,1 @@
+https://github.com/sigpanic/goink


### PR DESCRIPTION
Goink is a MIT-licensed desktop AI writing agent for long-form Chinese novels. Built with Wails v2 (Go + React 19), ships as AppImage <60MB.

- GitHub: https://github.com/sigpanic/goink
- Releases include 
- Offline-capable (local semantic search via ONNX Runtime)
- Desktop file included