### PR TITLE
Add OpenTypeless

### DIFF
--- a/data/OpenTypeless
+++ b/data/OpenTypeless
@@ -1,0 +1,1 @@
+https://github.com/tover0314-w/opentypeless/releases/download/v1.1.46/OpenTypeless_1.1.46_amd64.AppImage


### PR DESCRIPTION
Adds OpenTypeless to the AppImageHub catalog.\n\nOpenTypeless is an open-source AI voice input, rewriting, and voice Q&A desktop app for macOS, Windows, and Linux.\n\nAppImage URL used because the current release asset name does not follow the repository autodetection naming convention exactly.