### PR TITLE
Add kps

### DIFF
--- a/data/kps
+++ b/data/kps
@@ -1,0 +1,1 @@
+https://github.com/alanjmrt94/kps


### PR DESCRIPTION
Add kps to the AppImage catalog.

Repository: https://github.com/alanjmrt94/kps
Release: https://github.com/alanjmrt94/kps/releases/tag/v2.0.5

The AppImage is attached to GitHub Releases as `kps-x86_64.AppImage`.