### PR TITLE
Add CloakGuard

### DIFF
--- a/data/CloakGuard
+++ b/data/CloakGuard
@@ -1,0 +1,1 @@
+https://github.com/benthompsondev/cloakguard


### PR DESCRIPTION
Adding CloakGuard, a local-first, open-source (MIT) text redactor that removes secrets, credentials, and personal data from text before sharing. Built with Tauri v2.

- Repo: https://github.com/benthompsondev/cloakguard
- The x86_64 AppImage is published on the Releases page, built on Ubuntu 22.04, runs offline, and ships a valid desktop file plus AppStream metainfo.