### PR TITLE
Add Sloom Studio

### DIFF
--- a/data/Sloom_Studio
+++ b/data/Sloom_Studio
@@ -1,0 +1,5 @@
+https://github.com/Es00bac/signal-loom/releases/download/v0.9.11/SloomStudio-0.9.11-x86_64.AppImage
+# Sloom Studio. Repo: https://github.com/Es00bac/signal-loom
+# Direct-asset link (not a bare repo link) because the AppImage filename ("SloomStudio-...")
+# does not start with the repo name ("signal-loom"), so repo-link auto-detection would not
+# track future releases.


### PR DESCRIPTION
Sloom Studio (formerly Signal Loom): a local-first creative suite you own, with a layered
Image editor, comic and book desktop publishing (Paper), a multitrack Video editor, and an
optional AI node-graph (Flow), all sharing one project.

Free Community edition for personal/noncommercial use; a one-time commercial license
(sloom.studio) unlocks professional print-production exports (KDP, PDF/X, IDML, CMYK/spot).
Source-available under PolyForm Noncommercial 1.0.0 — not OSI open source.

AppImage: linux x86_64, built via electron-builder, attached to the GitHub Release above.
