### PR TITLE
Add Word Hunter

### DIFF
--- a/data/WordHunter
+++ b/data/WordHunter
@@ -1,0 +1,1 @@
+https://github.com/Ironship/WordHunter


### PR DESCRIPTION
Adds Word Hunter to the AppImageHub catalog using the application's GitHub Releases repository.

- Repository: https://github.com/Ironship/WordHunter
- Current AppImage: https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.6/WordHunter-1.0.6-x86_64.AppImage
- Submission file contains only the repository URL, as required by the catalog.