### PR TITLE
feat(catalog): add Flowtake

### DIFF
--- a/data/Flowtake
+++ b/data/Flowtake
@@ -1,0 +1,1 @@
+https://github.com/JNX03/Flowtake


### PR DESCRIPTION
## Summary

Adds Flowtake using its GitHub repository URL so the catalog worker can resolve the latest x64 AppImage from GitHub Releases.

## Pre-submission validation

- data file contains exactly one repository URL
- GitHub Releases API resolves `Flowtake_1.6.0_amd64.AppImage` (180,570,616 bytes)
- project URL returns HTTP 200
- `git diff --cached --check`

The catalog Test workflow is the compatibility gate for AppDir linting and an offline launch under Ubuntu/X11.
