### PR TITLE
Add a link to MieSimulatorGUI releases

### DIFF
--- a/data/MieSimulatorGUI
+++ b/data/MieSimulatorGUI
@@ -1,2 +1,2 @@
 https://github.com/VirtualPhotonics/MieSimulatorGUI/releases
-#
+


### PR DESCRIPTION
Released version 2.1
https://github.com/VirtualPhotonics/MieSimulatorGUI/releases

Link to latest AppImage
https://github.com/VirtualPhotonics/MieSimulatorGUI/releases/download/Version_2.1/MieSimulatorGUI_v2_1.AppImage