### PR TITLE
Add flocafe to catalog

### DIFF
--- a/data/flocafe
+++ b/data/flocafe
@@ -1,0 +1,1 @@
+https://github.com/FreeOpenSourcePOS/FloCafe


### PR DESCRIPTION
Adding **FloCafe** (`flocafe`) to the AppImageHub catalog.

FloCafe is a free, open-source, offline-first Point of Sale system for cafes, restaurants, and small kitchens. The catalog bot can pick up new AppImages automatically by scanning the [Releases page](https://github.com/FreeOpenSourcePOS/FloCafe/releases).

- Filename pattern matches the catalog auto-discovery regex: `flocafe-<version>-<arch>.AppImage` (x86_64 + arm64 both produced in CI)
- AppStream metainfo is bundled at `/usr/share/metainfo/com.flo.desktop.metainfo.xml`
- Linux release pipeline is wired for snap-store publishing too: `sudo snap install flocafe` for those who prefer the Snap channel

Latest release: https://github.com/FreeOpenSourcePOS/FloCafe/releases/latest
