### PR TITLE
Add WhereDidMyStorageGo

### DIFF
--- a/data/WhereDidMyStorageGo
+++ b/data/WhereDidMyStorageGo
@@ -1,0 +1,1 @@
+https://www.budbrain.de/appimage/wheredidmystoragego-x86_64.AppImage


### PR DESCRIPTION
Disk usage analyser for the Linux desktop, shown as a treemap. GTK3, x86_64.

The AppImage is built on an EL9 base, so it starts on the oldest supported Ubuntu LTS as well. The URL is version-less and always points to the current release.