### PR TITLE
Add TorReader PDF

### DIFF
--- a/data/TorReaderPDF
+++ b/data/TorReaderPDF
@@ -1,0 +1,2 @@
+https://github.com/FelixNgH/TorreaderPDF/releases/download/v2.2.4/TorReaderPDF-2.2.4-x86_64.AppImage
+# https://github.com/FelixNgH/TorreaderPDF/


### PR DESCRIPTION
TorReader PDF is a lightweight, portable PDF reader and editor for Linux and Windows, built with C++/Qt6 and PDFium. It opens large documents quickly, merges PDFs while preserving bookmarks, and splits, extracts, inserts and annotates pages — all offline.

- Homepage: https://torreader.cloud
- Source (MIT): https://github.com/FelixNgH/TorreaderPDF

The AppImage targets glibc 2.35, so it runs on Ubuntu 22.04+, Debian 12+ and Fedora 36+ (x86_64). It ships a freedesktop desktop entry and AppStream metainfo.

Submitting the direct AppImage URL rather than the repository URL because the repository name (`TorreaderPDF`) does not match the capitalisation of the AppImage filename (`TorReaderPDF-…`), which the automatic release detection requires.