### PR TITLE
Add Vantah

### DIFF
--- a/data/Vantah
+++ b/data/Vantah
@@ -1,0 +1,1 @@
+https://github.com/bolikcraft/vantah


### PR DESCRIPTION
Vantah is an unofficial GUI and system-tray front-end for the official `adguardvpn-cli` command-line tool on Linux. It does not implement a VPN itself and does not bundle any AdGuard software — it runs the CLI as an external process and shows its state in a graphical interface.

- Repository: https://github.com/bolikcraft/vantah
- License: GPL-3.0-or-later
- The AppImage is built for x86-64 in CI on every release and published on the releases page with a `.sha256` next to it.
- The AppDir ships a desktop file and an AppStream metainfo file (`io.github.bolikcraft.vantah.metainfo.xml`).
- Not affiliated with, endorsed by, or sponsored by AdGuard.