### PR TITLE
Add Onyx Launcher

### DIFF
--- a/data/Onyx_Launcher
+++ b/data/Onyx_Launcher
@@ -1,0 +1,1 @@
+https://github.com/lonestill/onyx-launcher


### PR DESCRIPTION
Adds the official Onyx Launcher repository. The latest release provides an x86_64 AppImage and SHA-256 checksums for this MIT-licensed Minecraft launcher.

Project website: https://lonestill.github.io