### PR TITLE
Add VerityPDF

### DIFF
--- a/data/VerityPDF
+++ b/data/VerityPDF
@@ -1,1 +1,1 @@
-https://github.com/JHoff1/VerityPDF/releases/latest/download/VerityPDF.AppImage
+https://github.com/JHoff1/VerityPDF/releases/download/v0.1.15/VerityPDF.AppImage

--- a/data/VerityPDF
+++ b/data/VerityPDF
@@ -1,0 +1,1 @@
+https://github.com/JHoff1/VerityPDF/releases/latest/download/VerityPDF.AppImage


### PR DESCRIPTION
Adds VerityPDF to AppImageHub.

VerityPDF is a free, open-source, local-first PDF editor for Linux, Windows, and macOS. The submitted URL is the stable GitHub Releases download for the latest AppImage.

- Source: https://github.com/JHoff1/VerityPDF
- Website: https://www.veritypdf.com/
- License: AGPL-3.0
- AppImage: public, offline-capable, and built on Ubuntu 22.04