### PR TITLE
Add VerityPDF

### DIFF
--- a/data/VerityPDF
+++ b/data/VerityPDF
@@ -1,0 +1,1 @@
+https://github.com/JHoff1/VerityPDF/releases/latest/download/VerityPDF.AppImage


### PR DESCRIPTION
Adds VerityPDF, a free and open-source local-first PDF editor. The submitted AppImage is publicly downloadable, runs without a network connection, and is published from the project's GitHub Releases page.

Project: https://github.com/JHoff1/VerityPDF
Website: https://www.veritypdf.com/
License: AGPL-3.0

The current v0.1.15 AppImage has been rebuilt with executable entry-point permissions and validated by GitHub Actions with an Xvfb launch smoke test.