### PR TITLE
Rename My-Honda-for-desktop to My-Honda-Plus-for-desktop

### DIFF
--- a/data/My-Honda-Plus-for-desktop
+++ b/data/My-Honda-Plus-for-desktop
@@ -1,0 +1,1 @@
+https://github.com/enricobattocchi/myhondaplus-desktop

--- a/data/My-Honda-for-desktop
+++ b/data/My-Honda-for-desktop
@@ -1,1 +1,0 @@
-https://github.com/enricobattocchi/myhondaplus-desktop


### PR DESCRIPTION
Renames the catalog entry for my own app from `My-Honda-for-desktop` to `My-Honda-Plus-for-desktop`.

The application is called "My Honda+ for desktop". The "+" was dropped from the file name when I submitted it, which also dropped the "Plus" from the catalog entry name. The AppImage is now released as `My-Honda-Plus-for-desktop-<version>-x86_64.AppImage`, so this brings the entry in line with it.

The file content (the link to the GitHub repository) is unchanged.
