### PR TITLE
worker.sh: don't abort when the AppImage is self-hosted

### DIFF
--- a/code/worker.sh
+++ b/code/worker.sh
@@ -507,8 +507,8 @@ sudo chmod a+x appstreamcli-x86_64.AppImage
   # BB_USER=$(grep "^https://bitbucket.org.*" data/$INPUTBASENAME | cut -d '/' -f 4 )
   # BB_REPO=$(grep "^https://bitbucket.org.*" data/$INPUTBASENAME | cut -d '/' -f 5 )
   if [  x"$GH_USER" == x"" ] ; then
-    GH_USER=$(grep "^https://api.github.com.*" data/$INPUTBASENAME | cut -d '/' -f 5 )
-    GH_REPO=$(grep "^https://api.github.com.*" data/$INPUTBASENAME | cut -d '/' -f 6 )
+    GH_USER=$(grep "^https://api.github.com.*" data/$INPUTBASENAME | cut -d '/' -f 5 ) || true
+    GH_REPO=$(grep "^https://api.github.com.*" data/$INPUTBASENAME | cut -d '/' -f 6 ) || true
   fi
   if [  x"$GH_USER" != x"" ] ; then
     echo "  - name: $GH_USER" >> apps/$INPUTBASENAME.md


### PR DESCRIPTION
Fixes #3822.

Both assignments lack the `|| true` that lines 500, 501 and 506 carry. With `bash -e` (see `.github/workflows/test.yml`) a `grep` that finds nothing ends the whole run.

The branch is only reached when the data file holds no `https://github.com/` URL — i.e. exactly for self-hosted AppImages, which therefore can never pass the check.

Same class of bug as #3678, fixed there in 86a5b18 the same way.