### PR TITLE
Add Frescobaldi

### DIFF
--- a/data/Frescobaldi
+++ b/data/Frescobaldi
@@ -1,0 +1,1 @@
+https://github.com/mlmateos/frescobaldi-qt6-builds


### PR DESCRIPTION
Unofficial optimized PyQt6/Qt 6.8 LTS builds of Frescobaldi. AppImage in GitHub Releases with AppStream metainfo.