### PR TITLE
Add FS PDF Compressor

### DIFF
--- a/data/FS-PDF-Compressor
+++ b/data/FS-PDF-Compressor
@@ -1,0 +1,1 @@
+https://github.com/gitlares/fs-pdf-compressor/releases/latest/download/FS-PDF-Compressor-x86_64.AppImage


### PR DESCRIPTION
Adds the public release URL for FS PDF Compressor, a self-contained x86_64 Linux AppImage.

The submitted URL is the stable GitHub Releases `latest/download` URL and resolves to the published AppImage asset.