### PR TITLE
Add flocafe to catalog

### DIFF
--- a/data/flocafe
+++ b/data/flocafe
@@ -1,0 +1,1 @@
+https://github.com/FreeOpenSourcePOS/FloCafe


### PR DESCRIPTION
Add FloCafe to the AppImageHub catalog.

FloCafe is a free, open-source, offline-first Point of Sale for cafes, restaurants, and small kitchens. The catalog bot picks up new AppImages by scanning the Releases page.

- AppImage assets match the catalog auto-discovery pattern (flocafe-<version>-x86_64.AppImage; arm64 is also produced in CI)
- AppStream metainfo is bundled at /usr/share/metainfo/com.flo.desktop.metainfo.xml
- The Linux release pipeline also publishes to the Snap Store (sudo snap install flocafe)

Latest release: https://github.com/FreeOpenSourcePOS/FloCafe/releases/latest