### PR TITLE
Add KIT Scenarist Community Build for Ubuntu 24.04

### DIFF
--- a/data/kit-scenarist-ubuntu24
+++ b/data/kit-scenarist-ubuntu24
@@ -1,0 +1,1 @@
+https://github.com/macassiu/KIT-Scenarist


### PR DESCRIPTION
## Add KIT Scenarist Community Build to AppImageHub

**KIT Scenarist Community Build** is a community-maintained version of the screenwriting software, specifically compiled for modern Linux distributions (Ubuntu 24.04+).

### ✨ Key features
- ✅ **URL crash bug fixed** – The application no longer crashes when opening links
- ✅ Compiled with Qt 5.15.13
- ✅ Self-contained AppImage with all dependencies
- ✅ Tested on Ubuntu Studio 24.04 and Ubuntu 24.04 LTS

### 📦 AppImage details
- **Version**: v0.8.0
- **Repository**: https://github.com/macassiu/KIT-Scenarist
- **License**: GPL-3.0

### 🔗 Relation to existing entry
This is a **community-maintained fork** of KIT Scenarist. The existing `kit-scenarist` entry points to the original project which is no longer maintained. This build provides fixes and compatibility for modern systems.

Thank you for considering this addition!