### PR TITLE
Add FS PDF Compressor

### DIFF
--- a/data/fs-pdf-compressor
+++ b/data/fs-pdf-compressor
@@ -1,0 +1,1 @@
+https://github.com/gitlares/fs-pdf-compressor


### PR DESCRIPTION
Adds the upstream GitHub repository for FS PDF Compressor. The current AppImage is published from the v1.0.11 GitHub release at a permanent release URL.