### PR TITLE
Add MapMap-Ubuntu24 file with project link

### DIFF
--- a/data/MapMap-Ubuntu24
+++ b/data/MapMap-Ubuntu24
@@ -1,0 +1,1 @@
+https://github.com/macassiu/mapmap-qt6-build


### PR DESCRIPTION
Video Mapping software.
> **Unofficial build** — Self-contained AppImage of MapMap v0.6.3 compiled with **Qt6** for modern Linux distributions.