### PR TITLE
Add Mongrel

### DIFF
--- a/data/Mongrel
+++ b/data/Mongrel
@@ -1,0 +1,1 @@
+https://downloads.visorcraft.com/mongrel/5.71.41/Mongrel_5.71.41_amd64.AppImage

--- a/data/Mongrel
+++ b/data/Mongrel
@@ -1,1 +1,1 @@
-https://downloads.visorcraft.com/mongrel/5.71.41/Mongrel_5.71.41_amd64.AppImage
+https://downloads.visorcraft.com/mongrel/5.71.42/Mongrel_5.71.42_amd64.AppImage


### PR DESCRIPTION
Adds **Mongrel** to the AppImage catalog via a one-line entry in `data/Mongrel`, pointing to the official AppImage:

https://downloads.visorcraft.com/mongrel/5.71.41/Mongrel_5.71.41_amd64.AppImage

- Website: https://www.visorcraft.com/
- Download page: https://www.visorcraft.com/download
- Mongrel is a desktop database systems workbench (30+ database engines, SSH/Mosh/Telnet/Serial terminals, SFTP/SCP, Docker/Podman, Kubernetes, HTTP/GraphQL/WebSocket/gRPC API client), built with Tauri v2 and a Rust backend, for Windows, macOS (Apple silicon), and Linux.

Disclosure: I am submitting on behalf of VisorCraft, the vendor of Mongrel. Mongrel is proprietary, paid software (annual license) with a free 7-day trial; the AppImage above is publicly downloadable without authentication.