### PR TITLE
Add Posnic

### DIFF
--- a/data/Posnic
+++ b/data/Posnic
@@ -1,0 +1,1 @@
+https://github.com/Posnic/POS/releases/download/v1.6.1/Posnic-1.6.1-linux-x86_64.AppImage


### PR DESCRIPTION
Adds the official Posnic v1.6.1 x86_64 AppImage published by the upstream Posnic/POS project.

Release: https://github.com/Posnic/POS/releases/tag/v1.6.1
AppImage: https://github.com/Posnic/POS/releases/download/v1.6.1/Posnic-1.6.1-linux-x86_64.AppImage
SHA-256: f2b2d620ea9f86040293c42ad7b066d9b5b754abfc56040574a9223a2dafc9fc

The catalog workflow remains the authority for AppImage metadata, lint, compatibility, offline-launch and screenshot checks. A direct AppImage URL is used because the AppImage filename starts with `Posnic` while the GitHub repository is named `POS`, so the repository-level auto-detection naming rule may not apply cleanly.