### PR TITLE
Add ImgConvert

### DIFF
--- a/data/ImgConvert
+++ b/data/ImgConvert
@@ -1,0 +1,1 @@
+https://github.com/web-casa/ImgConvert

--- a/data/ImgConvert
+++ b/data/ImgConvert
@@ -1,1 +1,1 @@
-https://github.com/web-casa/ImgConvert
+https://github.com/web-casa/ImgConvert/


### PR DESCRIPTION
Adds ImgConvert to the AppImageHub catalog.

The canonical x86_64 AppImage is available from the public v0.2.7 release and follows the repository/version/architecture naming convention. Image conversion runs locally and works without network access.