### PR TITLE
Add LibreDB Studio

### DIFF
--- a/data/LibreDB_Studio
+++ b/data/LibreDB_Studio
@@ -1,0 +1,1 @@
+https://github.com/libredb/libredb-studio


### PR DESCRIPTION
Adds LibreDB Studio, an open source SQL IDE for PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, ClickHouse, Trino, Cassandra and a few more engines. The desktop build runs the whole app locally, so it needs no account and no network connection.

The AppImage is published on GitHub Releases for x86_64 and aarch64 on every release:
https://github.com/libredb/libredb-studio/releases/latest

I checked it against the review requirements on Ubuntu 22.04 before opening this PR:

- starts with networking disabled and opens its main window in about a second
- appdir-lint.sh and desktop-file-validate both pass
- no library requires a glibc newer than 22.04's 2.35

The one thing it does not have yet is an AppStream metainfo file, so the description comes from the desktop file for now.
