### PR TITLE
Add LibreMerge

### DIFF
--- a/data/LibreMerge
+++ b/data/LibreMerge
@@ -1,0 +1,1 @@
+https://github.com/iagodpassos/libremerge


### PR DESCRIPTION
Adds [LibreMerge](https://github.com/iagodpassos/libremerge), a free differencing and merging tool for Linux and macOS (GPL-3.0-or-later): a Qt 6 port of the WinMerge comparison engine with side-by-side file compare and merge (2- and 3-way), folder comparison, CSV/TSV table comparison, image comparison, syntax highlighting, and light/dark themes.

AppImages for x86_64 and aarch64 are published on the GitHub releases page. The x86_64 AppImage was tested on a clean Ubuntu 22.04 (offscreen and X11/Xvfb) with the app's built-in selftests.