### PR TITLE
Add quiq to catalog

### DIFF
--- a/data/quiq
+++ b/data/quiq
@@ -1,0 +1,1 @@
+https://github.com/trueshanti/quiq/


### PR DESCRIPTION
Adds https://github.com/trueshanti/quiq/ to the catalog. Releases include an x86_64 AppImage following standard nomenclature (quiq-VERSION-x86_64.AppImage) plus a zsync file for updates.