### PR TITLE
worker.sh: read AppStream metainfo under its current name (*.metainfo.xml) too

### DIFF
--- a/code/worker.sh
+++ b/code/worker.sh
@@ -445,11 +445,16 @@ sudo chmod a+x appstreamcli-x86_64.AppImage
   echo "layout: app" >> apps/$INPUTBASENAME.md
   echo "" >> apps/$INPUTBASENAME.md
   echo "permalink: /$INPUTBASENAME/" >> apps/$INPUTBASENAME.md
+  # AppStream metainfo is named either <id>.appdata.xml (legacy) or
+  # <id>.metainfo.xml (current); both are copied in above, so use whichever is
+  # there. Applications shipping the current name would otherwise silently fall
+  # back to the .desktop Comment and to the automatically taken screenshot.
+  AS_XML=$(ls database/$INPUTBASENAME/*.appdata.xml database/$INPUTBASENAME/*.metainfo.xml 2>/dev/null | head -n 1)
   # Description
   DESKTOP_COMMENT=$(grep "^Comment=.*" database/$INPUTBASENAME/*.desktop | cut -d '=' -f 2- ) || true
-  if [ -f database/$INPUTBASENAME/*appdata.xml ] ; then
-    ./appstreamcli-x86_64.AppImage convert database/$INPUTBASENAME/*appdata.xml database/$INPUTBASENAME/appdata.yaml
-    SUMMARY=$(cat database/$INPUTBASENAME/*appdata.xml | xmlstarlet sel -t -m "/component/summary[1]" -v .) || true
+  if [ -n "$AS_XML" ] ; then
+    ./appstreamcli-x86_64.AppImage convert "$AS_XML" database/$INPUTBASENAME/appdata.yaml
+    SUMMARY=$(xmlstarlet sel -t -m "/component/summary[1]" -v . "$AS_XML") || true
     if [ x"$SUMMARY" != x"" ] ; then
       echo "description: $SUMMARY" >> apps/$INPUTBASENAME.md
     fi
@@ -483,8 +488,8 @@ sudo chmod a+x appstreamcli-x86_64.AppImage
     echo "  - $INPUTBASENAME/icons/$ICONSIZE/$ICONBASENAME" >> apps/$INPUTBASENAME.md
   fi
   # Screenshot
-  if [ -f database/$INPUTBASENAME/*appdata.xml ] ; then
-    SCREENSHOT=$(cat database/$INPUTBASENAME/*appdata.xml | xmlstarlet sel -t -m "/component/screenshots/screenshot[1]/image" -v . || true)
+  if [ -n "$AS_XML" ] ; then
+    SCREENSHOT=$(xmlstarlet sel -t -m "/component/screenshots/screenshot[1]/image" -v . "$AS_XML" || true)
     if [ x"$SCREENSHOT" != x"" ] ; then
       echo "screenshots:" >> apps/$INPUTBASENAME.md
       echo "- $SCREENSHOT" >> apps/$INPUTBASENAME.md


### PR DESCRIPTION
### Problem

`code/worker.sh` copies in **both** AppStream file names (lines 385-391):

```bash
if [ -e $APPDIR/usr/share/metainfo/*.appdata.xml ] ; then ... fi
if [ -e $APPDIR/usr/share/metainfo/*.metainfo.xml ] ; then ... fi
```

but it only ever *reads* `*appdata.xml`:

```bash
if [ -f database/$INPUTBASENAME/*appdata.xml ] ; then      # description
if [ -f database/$INPUTBASENAME/*appdata.xml ] ; then      # screenshot
```

`*.metainfo.xml` is the name the AppStream specification asks for today, so any
application using it silently falls back to the `.desktop` `Comment=` for the
description and to the automatically taken screenshot — even though its metainfo
file was shipped, copied in, and is perfectly readable.

That it *is* readable is easy to show: the license block right between those two
`if`s already handles both names via `*.{appdata,metainfo}.xml`, and the license
from such a file does end up in the catalogue entry. Only description and
screenshot are lost.

### Change

One variable, used by both blocks, preferring `*.appdata.xml` when an
application ships both:

```bash
AS_XML=$(ls database/$INPUTBASENAME/*.appdata.xml database/$INPUTBASENAME/*.metainfo.xml 2>/dev/null | head -n 1)
```

As a side effect this also removes two `[ -f <glob> ]` tests, which fail with
"too many arguments" when an AppDir ships more than one matching file.

### Tested

| files present | before | after |
|---|---|---|
| only `*.metainfo.xml` | not detected | detected |
| only `*.appdata.xml` | detected | detected (unchanged) |
| both | detected | detected, `appdata.xml` preferred (unchanged) |
| neither | falls back | falls back (unchanged) |

With a real AppImage shipping only `de.budbrain.jsPicPuzzler.metainfo.xml`, the
two XPath expressions now return
`Jigsaw puzzles from forty photographs, in six sizes` and the screenshot URL from
the metainfo, instead of nothing.
