### PR TITLE
Add SubnetDesk

### DIFF
--- a/data/SubnetDesk
+++ b/data/SubnetDesk
@@ -1,0 +1,1 @@
+https://github.com/zibo-chen/SubnetDesk/releases/download/v1.3.0/subnetdesk-1.3.0-x86_64.AppImage


### PR DESCRIPTION
Adds the x86_64 AppImage for SubnetDesk v1.3.0.

SubnetDesk is an AGPL-3.0 LAN/VPN-only remote desktop based on RustDesk. The submitted AppImage is hosted on the project’s public GitHub Releases page.