### PR TITLE
Create QCADesigner-E

### DIFF
--- a/data/QCADesigner-E
+++ b/data/QCADesigner-E
@@ -1,0 +1,1 @@
+https://github.com/Pratyay360/QCADesigner-E/releases/download/main/QCADesignerE-x86_64.AppImage


### PR DESCRIPTION
The QCADesigner-E is an extension of the QCADesigner (version 2.0.3) [1] and has been developed at the University of Bremen. The tool, which has been presented in [2] (https://doi.org/10.1109/TCAD.2018.2789782), implements the estimation of the power dissipation of QCA circuits based on the works of Timler and Lent et al. [3-5]. The extension is integrated as an additional simulation module that is based on the Coherence Vector Simulation Engine (CVSE). Further, The QCADesigner-E is fully compatible to QCA designs generated with the QCADesigner version 2.0.3.

license: GPL-3.0
QCADesigner-E is free to use and to modify.  

screenshots: 

<img width="1919" height="1070" alt="image" src="https://github.com/user-attachments/assets/943c61b2-0d75-4412-bef7-69cf59f2f295" />
